### PR TITLE
prevent popover flicker

### DIFF
--- a/src/us-map.js
+++ b/src/us-map.js
@@ -100,8 +100,8 @@
                     });
 
                     stElem.on('mousemove', function(e) {
-                        elem.css('left', e.clientX+'px');
-                        elem.css('top', e.clientY+'px');
+                        elem.css('left', e.clientX+10+'px');
+                        elem.css('top', e.clientY+10+'px');
                     });
 
                     stElem.on('mouseout', function() {


### PR DESCRIPTION
the mouseenter causes the popover to show, but mouseout causes it to hide. rendering the popover directly under the cursor causes a mouseout event to fire, so the popover constantly flickers between showing and hiding unless you move the cursor away faster than it can render and register the mouseout event. moving the popover a bit solves the issue.